### PR TITLE
feat: 2025.07.29

### DIFF
--- a/app/src/main/java/com/stip/api/repository/TapiHourlyDataRepository.kt
+++ b/app/src/main/java/com/stip/api/repository/TapiHourlyDataRepository.kt
@@ -20,21 +20,10 @@ class TapiHourlyDataRepository {
      * @return 시간별 거래 데이터 리스트
      */
     suspend fun getTodayHourlyData(marketPairId: String): List<TapiHourlyDataResponse> {
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
         val today = Calendar.getInstance()
-//        // 오늘 00:00:00
-//        today.set(Calendar.HOUR_OF_DAY, 0)
-//        today.set(Calendar.MINUTE, 0)
-//        today.set(Calendar.SECOND, 0)
-//        today.set(Calendar.MILLISECOND, 0)
-//        val from = dateFormat.format(today.time)
-//        // 오늘 23:59:59
-//        today.set(Calendar.HOUR_OF_DAY, 23)
-//        today.set(Calendar.MINUTE, 59)
-//        today.set(Calendar.SECOND, 59)
-//        val to = dateFormat.format(today.time)
-        val from = "2025-07-01T00:00:00Z"
-        val to = "2025-07-31T23:59:59Z"
+        val from = "2025-07-01"
+        val to = "2025-07-31"
         return try {
             tapiService.getHourlyData(marketPairId, from, to)
         } catch (e: Exception) {
@@ -49,21 +38,10 @@ class TapiHourlyDataRepository {
      * @return 시간별 거래 데이터 리스트
      */
     suspend fun getHourlyDataByDate(marketPairId: String, date: Date): List<TapiHourlyDataResponse> {
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
-        val calendar = Calendar.getInstance().apply { time = date }
-        // 해당 날짜 00:00:00
-        calendar.set(Calendar.HOUR_OF_DAY, 0)
-        calendar.set(Calendar.MINUTE, 0)
-        calendar.set(Calendar.SECOND, 0)
-        calendar.set(Calendar.MILLISECOND, 0)
-        val from = dateFormat.format(calendar.time)
-        // 해당 날짜 23:59:59
-        calendar.set(Calendar.HOUR_OF_DAY, 23)
-        calendar.set(Calendar.MINUTE, 59)
-        calendar.set(Calendar.SECOND, 59)
-        val to = dateFormat.format(calendar.time)
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        val dateStr = dateFormat.format(date)
         return try {
-            tapiService.getHourlyData(marketPairId, from, to)
+            tapiService.getHourlyData(marketPairId, dateStr, dateStr)
         } catch (e: Exception) {
             emptyList()
         }
@@ -81,7 +59,7 @@ class TapiHourlyDataRepository {
         from: Date,
         to: Date
     ): List<TapiHourlyDataResponse> {
-        val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
         val fromStr = dateFormat.format(from)
         val toStr = dateFormat.format(to)
         return try {

--- a/app/src/main/java/com/stip/api/service/TapiHourlyDataService.kt
+++ b/app/src/main/java/com/stip/api/service/TapiHourlyDataService.kt
@@ -12,8 +12,8 @@ interface TapiHourlyDataService {
     /**
      * 시간별 거래 데이터 조회
      * @param marketPairId 마켓 페어 ID
-     * @param from 시작 시각 (ISO 8601 형식)
-     * @param to 종료 시각 (ISO 8601 형식)
+     * @param from 시작 날짜 (YYYY-MM-DD 형식)
+     * @param to 종료 날짜 (YYYY-MM-DD 형식)
      * @return 시간별 거래 데이터 배열
      */
     @GET("api/tickers/hourly")

--- a/app/src/main/java/com/stip/iphome/adapter/QuotesAdapter.kt
+++ b/app/src/main/java/com/stip/iphome/adapter/QuotesAdapter.kt
@@ -36,9 +36,9 @@ class QuotesAdapter(private val context: Context) : ListAdapter<QuoteTick, Quote
 
             // 가격 변동 상태에 따라 텍스트 색상 변경
             val priceColor = when (quote.priceChangeStatus) {
-                PriceChangeStatus.UP -> ContextCompat.getColor(context, R.color.color_rise)
-                PriceChangeStatus.DOWN -> ContextCompat.getColor(context, R.color.color_fall)
-                PriceChangeStatus.SAME -> ContextCompat.getColor(context, R.color.price_same_color)
+                PriceChangeStatus.UP -> ContextCompat.getColor(context, R.color.color_fall)     // 상승: 파란색
+                PriceChangeStatus.DOWN -> ContextCompat.getColor(context, R.color.color_rise)   // 하락: 빨간색
+                PriceChangeStatus.SAME -> ContextCompat.getColor(context, R.color.price_same_color) // 동일: 검은색
             }
             binding.itemPriceTextView.setTextColor(priceColor)
         }

--- a/app/src/main/java/com/stip/iphome/fragment/IpHomeQuotesFragment.kt
+++ b/app/src/main/java/com/stip/iphome/fragment/IpHomeQuotesFragment.kt
@@ -168,19 +168,24 @@ class IpHomeQuotesFragment : Fragment() {
                     return@launch
                 }
 
-                // 시간별 데이터를 시간 순으로 정렬 (최신순)
-                val sortedData = hourlyData.sortedByDescending { it.timestamp }
-                
-                // 기존 데이터 초기화 (첫 로드시에만)
-                if (isFirstLoad) {
-                    timeQuotesList.clear()
+                // 시간별 데이터를 시간 순으로 정렬 (최신순) - 실제 Date 객체로 파싱하여 정확한 시간 순서 비교
+                val timeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS", Locale.getDefault()).apply {
+                    timeZone = java.util.TimeZone.getTimeZone("UTC")
                 }
-
-                // 새로운 데이터 추가
-                sortedData.forEach { hourlyItem ->
-                    val timeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).apply {
-                        timeZone = java.util.TimeZone.getTimeZone("UTC")
+                val sortedData = hourlyData.sortedByDescending { hourlyItem ->
+                    try {
+                        timeFormat.parse(hourlyItem.timestamp)?.time ?: 0L
+                    } catch (e: Exception) {
+                        Log.e(TAG, "시간 파싱 오류: ${hourlyItem.timestamp}", e)
+                        0L
                     }
+                }
+                
+                // 매번 새로운 데이터로 교체 (최신순 정렬된 데이터 사용)
+                timeQuotesList.clear()
+
+                // 최신순으로 정렬된 데이터를 순서대로 추가 (최대 30개)
+                sortedData.take(30).forEachIndexed { index, hourlyItem ->
                     val displayFormat = SimpleDateFormat("HH:mm:ss", Locale.getDefault()).apply {
                         timeZone = java.util.TimeZone.getTimeZone("Asia/Seoul")
                     }
@@ -189,10 +194,17 @@ class IpHomeQuotesFragment : Fragment() {
                         val timestamp = timeFormat.parse(hourlyItem.timestamp)
                         val displayTime = displayFormat.format(timestamp)
                         
-                        val priceChangeStatus = when {
-                            hourlyItem.price > lastPrice -> PriceChangeStatus.UP
-                            hourlyItem.price < lastPrice -> PriceChangeStatus.DOWN
-                            else -> PriceChangeStatus.SAME
+                        // 이전 거래와의 시간 순서 비교로 가격 변동 상태 결정
+                        val priceChangeStatus = if (index < sortedData.size - 1) {
+                            val previousItem = sortedData[index + 1] // 시간상 이전 거래
+                            when {
+                                hourlyItem.price > previousItem.price -> PriceChangeStatus.UP
+                                hourlyItem.price < previousItem.price -> PriceChangeStatus.DOWN
+                                else -> PriceChangeStatus.SAME
+                            }
+                        } else {
+                            // 첫 번째 거래(가장 최신)는 이전 거래가 없으므로 SAME으로 처리
+                            PriceChangeStatus.SAME
                         }
 
                         val newQuote = QuoteTick(
@@ -203,17 +215,8 @@ class IpHomeQuotesFragment : Fragment() {
                             priceChangeStatus = priceChangeStatus
                         )
 
-                        // 중복 방지
-                        val existingIndex = timeQuotesList.indexOfFirst { it.id == newQuote.id }
-                        if (existingIndex == -1) {
-                            timeQuotesList.add(0, newQuote)
-                            if (timeQuotesList.size > 30) {
-                                timeQuotesList.removeAt(timeQuotesList.size - 1)
-                            }
-                        }
-
-                        lastPrice = hourlyItem.price
-                        Log.d(TAG, "시간별 시세 업데이트 - 시간: $displayTime, 가격: ${hourlyItem.price}, 체결량: ${hourlyItem.volume}")
+                        timeQuotesList.add(newQuote)
+                        Log.d(TAG, "시간별 시세 업데이트 - 시간: $displayTime, 가격: ${hourlyItem.price}, 체결량: ${hourlyItem.volume}, 상태: $priceChangeStatus")
                     } catch (e: Exception) {
                         Log.e(TAG, "시간 파싱 오류: ${e.message}")
                     }

--- a/app/src/main/java/com/stip/iphome/fragment/OrderContentViewFragment.kt
+++ b/app/src/main/java/com/stip/iphome/fragment/OrderContentViewFragment.kt
@@ -121,6 +121,9 @@ class OrderContentViewFragment : Fragment(), OnOrderBookItemClickListener {
                         orderButtonHandler.updateOrderButtonStates()
                         // 포트폴리오 데이터 새로고침
                         loadPortfolioData()
+                        
+                        // 실시간 시세 동기화를 위한 호가창 업데이트
+                        orderBookManager.triggerManualUpdate()
                     } catch (e: Exception) {
                         Log.e(TAG, "잔액 업데이트 중 UI 오류", e)
                     }
@@ -202,7 +205,12 @@ class OrderContentViewFragment : Fragment(), OnOrderBookItemClickListener {
                         .find { it.ticker == orderDataCoordinator.currentTicker }?.registrationNumber 
                 },
                 orderDataCoordinator = orderDataCoordinator,
-                orderInputHandler = orderInputHandler
+                orderInputHandler = orderInputHandler,
+                onOrderSuccess = {
+                    // 주문 성공 시 호가창 즉시 업데이트
+                    orderBookManager.triggerManualUpdate()
+                    Log.d(TAG, "주문 성공 후 호가창 업데이트 트리거")
+                }
             )
 
             uiStateManager = OrderUIStateManager(

--- a/app/src/main/java/com/stip/iphome/fragment/TradingChartFragment.kt
+++ b/app/src/main/java/com/stip/iphome/fragment/TradingChartFragment.kt
@@ -216,10 +216,10 @@ class TradingChartFragment : Fragment() {
         try {
             // 현재 날짜 기준으로 3개월 전부터 현재까지 데이터 요청
             val calendar = Calendar.getInstance()
-            val endDate = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).format(calendar.time)
+            val endDate = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(calendar.time)
             
             calendar.add(Calendar.MONTH, -3)
-            val startDate = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).format(calendar.time)
+            val startDate = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(calendar.time)
             
             val url = URL("$API_BASE_URL/api/tickers/hourly?marketPairId=$pairId&from=$startDate&to=$endDate")
             val connection = url.openConnection()

--- a/app/src/main/java/com/stip/iptransaction/adapter/IpInvestmentAdapter.kt
+++ b/app/src/main/java/com/stip/iptransaction/adapter/IpInvestmentAdapter.kt
@@ -9,6 +9,7 @@ import com.stip.stip.databinding.ItemIpIvestmentFillteredBinding
 import com.stip.stip.iptransaction.model.IpInvestmentItem
 import java.text.DecimalFormat
 import java.util.Locale
+import android.util.Log
 
 class IpInvestmentAdapter(
     private var items: List<IpInvestmentItem> = emptyList()
@@ -61,20 +62,24 @@ class IpInvestmentAdapter(
             binding.textViewItemQuantity.text = formatNumber(item.quantity)
             binding.textViewItemUnitPrice.text = formatCurrency(item.unitPrice)
             binding.textViewItemAmount.text = formatCurrency(item.amount)
-            
             binding.textViewItemFee.text = formatCurrencyWithCheck(item.fee)
-            
-            binding.textViewItemSettlement.text = formatCurrencyWithCheck(item.settlement)
+            Log.d("IpInvestmentAdapter", "settlement=${item.settlement}")
+            binding.textViewItemSettlement.text = formatCurrency(item.settlement)
             binding.textViewItemOrderTime.text = item.orderTime
             binding.textViewItemExecutionTime.text = item.executionTime
         }
 
         private fun formatCurrency(value: String): String {
+            if (value.isBlank() || value == "-") return "-"
             return try {
-                val bigDecimal = java.math.BigDecimal(value)
-                "$${bigDecimal.stripTrailingZeros().toPlainString()}"
+                val cleanValue = value.replace("$", "").trim()
+                val bigDecimal = java.math.BigDecimal(cleanValue)
+                val df = DecimalFormat("#,##0.0000").apply {
+                    roundingMode = java.math.RoundingMode.DOWN
+                }
+                "$${df.format(bigDecimal)}"
             } catch (e: Exception) {
-                "$0"
+                value
             }
         }
 

--- a/app/src/main/java/com/stip/order/adapter/OrderBookAdapter.kt
+++ b/app/src/main/java/com/stip/order/adapter/OrderBookAdapter.kt
@@ -30,7 +30,8 @@ class OrderBookAdapter(
     private var openPrice: Float = 0f
     private var maxValueForScale: Float = 1f
     private var currentDisplayModeIsTotalAmount: Boolean = false
-    private var highlightedPosition: Int = -1
+    private var highlightedPrice: String? = null
+    private var lastTradePrice: Float = 0f
 
     private val twoDecimalFormatter = DecimalFormat("#,##0.00").apply {
         decimalFormatSymbols = decimalFormatSymbols.apply {
@@ -71,89 +72,105 @@ class OrderBookAdapter(
     fun updateData(newList: List<OrderBookItem>, newCurrentPrice: Float) {
         Log.d(TAG, "🔁 updateData called with newCurrentPrice = $newCurrentPrice")
 
-        val oldCurrentPrice = this.currentPrice
-        this.currentPrice = newCurrentPrice
-        this.maxValueForScale = calculateMaxValue(newList.filter { !it.isGap }, currentDisplayModeIsTotalAmount)
-
-        // 간격 아이템 제거 - 실제 호가만 표시
         val listWithoutGap = newList.filter { !it.isGap }
 
-        // 현재 가격과 가장 가까운 행 찾기
+        // 하이라이트 position 계산
         var closestPosition = -1
         var minDifference = Float.MAX_VALUE
         var exactMatchPosition = -1
-        
+        val priceThreshold = 0.001f
         listWithoutGap.forEachIndexed { index, item ->
             try {
                 val itemPrice = numberParseFormat.parse(item.price)?.toFloat() ?: 0f
                 if (itemPrice > 0) {
-                    // 정확히 일치하는 경우 우선 저장
-                    if (itemPrice == newCurrentPrice) {
-                        exactMatchPosition = index
-                    }
-                    
                     val difference = kotlin.math.abs(itemPrice - newCurrentPrice)
+                    if (difference <= priceThreshold) {
+                        if (exactMatchPosition == -1) {
+                            exactMatchPosition = index
+                        }
+                    }
                     if (difference < minDifference) {
                         minDifference = difference
                         closestPosition = index
                     }
                 }
-            } catch (e: Exception) {
-                Log.e(TAG, "가격 파싱 하이라이트 에러", e)
+            } catch (_: Exception) {}
+        }
+        val newHighlightedPosition = if (exactMatchPosition != -1) exactMatchPosition else -1
+        val oldHighlightedPrice = highlightedPrice
+        highlightedPrice = if (newHighlightedPosition != -1) listWithoutGap.getOrNull(newHighlightedPosition)?.price else null
+
+        this.currentPrice = newCurrentPrice
+        this.maxValueForScale = calculateMaxValue(listWithoutGap, currentDisplayModeIsTotalAmount)
+
+        submitList(listWithoutGap) {
+            if (oldHighlightedPrice != highlightedPrice) {
+                val oldIdx = if (oldHighlightedPrice != null) listWithoutGap.indexOfFirst { it.price == oldHighlightedPrice } else -1
+                if (oldIdx != -1) notifyItemChanged(oldIdx)
+                val newIdx = if (highlightedPrice != null) listWithoutGap.indexOfFirst { it.price == highlightedPrice } else -1
+                if (newIdx != -1) notifyItemChanged(newIdx)
             }
         }
-        
-        val oldHighlightedPosition = highlightedPosition
-        // 정확히 일치하는 호가가 있으면 그것을 사용, 없으면 가장 가까운 호가 사용
-        highlightedPosition = if (exactMatchPosition != -1) exactMatchPosition else closestPosition
-
-        submitList(listWithoutGap)
         Log.d(TAG, "✅ Final list submitted. Size: ${listWithoutGap.size}, MaxValue: $maxValueForScale")
     }
 
     fun updateCurrentPrice(newPrice: Float) {
-        this.currentPrice = newPrice
-        
-        // 현재 리스트에서 현재가와 가장 가까운 위치 다시 계산
-        val currentList = currentList.filter { !it.isGap }
+        Log.d(TAG, "🔁 updateCurrentPrice called with newPrice = $newPrice")
+
+        val currentListNoGap = currentList.filter { !it.isGap }
         var closestPosition = -1
         var minDifference = Float.MAX_VALUE
         var exactMatchPosition = -1
-        
-        currentList.forEachIndexed { index, item ->
+        val priceThreshold = 0.001f
+        currentListNoGap.forEachIndexed { index, item ->
             try {
                 val itemPrice = numberParseFormat.parse(item.price)?.toFloat() ?: 0f
                 if (itemPrice > 0) {
-                    // 정확히 일치하는 경우 우선 저장
-                    if (itemPrice == newPrice) {
-                        exactMatchPosition = index
-                    }
-                    
                     val difference = kotlin.math.abs(itemPrice - newPrice)
+                    if (difference <= priceThreshold) {
+                        if (exactMatchPosition == -1) {
+                            exactMatchPosition = index
+                        }
+                    }
                     if (difference < minDifference) {
                         minDifference = difference
                         closestPosition = index
                     }
                 }
-            } catch (e: Exception) {
-                Log.e(TAG, "가격 파싱 하이라이트 에러", e)
-            }
+            } catch (_: Exception) {}
         }
-        
-        val oldHighlightedPosition = highlightedPosition
-        // 정확히 일치하는 호가가 있으면 그것을 사용, 없으면 가장 가까운 호가 사용
-        highlightedPosition = if (exactMatchPosition != -1) exactMatchPosition else closestPosition
-        
-        // 하이라이트가 변경된 경우에만 해당 아이템들 업데이트
-        if (oldHighlightedPosition != highlightedPosition) {
-            if (oldHighlightedPosition >= 0 && oldHighlightedPosition < itemCount) {
-                notifyItemChanged(oldHighlightedPosition)
-            }
-            if (highlightedPosition >= 0 && highlightedPosition < itemCount) {
-                notifyItemChanged(highlightedPosition)
-            }
-        } else {
-            // 하이라이트 위치가 같아도 현재가가 변경되었으므로 전체 업데이트
+        val newHighlightedPosition = if (exactMatchPosition != -1) exactMatchPosition else -1
+        val oldHighlightedPrice = highlightedPrice
+        highlightedPrice = if (newHighlightedPosition != -1) currentListNoGap.getOrNull(newHighlightedPosition)?.price else null
+
+        this.currentPrice = newPrice
+        if (oldHighlightedPrice != highlightedPrice) {
+            val oldIdx = if (oldHighlightedPrice != null) currentListNoGap.indexOfFirst { it.price == oldHighlightedPrice } else -1
+            if (oldIdx != -1) notifyItemChanged(oldIdx)
+            val newIdx = if (highlightedPrice != null) currentListNoGap.indexOfFirst { it.price == highlightedPrice } else -1
+            if (newIdx != -1) notifyItemChanged(newIdx)
+        }
+    }
+
+    /**
+     * 마지막 체결 가격에 맞는 호가만 하이라이트 (price 기준)
+     */
+    fun updateTradePrice(newTradePrice: Float) {
+        lastTradePrice = newTradePrice
+
+        val currentListNoGap = currentList.filter { !it.isGap }
+        var foundPrice: String? = null
+        currentListNoGap.forEach { item ->
+            try {
+                val itemPrice = numberParseFormat.parse(item.price)?.toFloat() ?: 0f
+                if (itemPrice > 0 && itemPrice == lastTradePrice) {
+                    foundPrice = item.price
+                }
+            } catch (_: Exception) {}
+        }
+        val oldHighlightedPrice = highlightedPrice
+        highlightedPrice = foundPrice
+        if (oldHighlightedPrice != highlightedPrice) {
             notifyDataSetChanged()
         }
     }
@@ -171,6 +188,18 @@ class OrderBookAdapter(
 
     fun getFirstBuyOrderIndex(): Int {
         return currentList.indexOfFirst { it.isBuy }
+    }
+    
+    /**
+     * 강조 표시를 완전히 초기화
+     */
+    fun resetHighlight() {
+        val oldHighlightedPrice = highlightedPrice
+        highlightedPrice = null
+        if (oldHighlightedPrice != null) {
+            val idx = currentList.indexOfFirst { it.price == oldHighlightedPrice }
+            if (idx != -1) notifyItemChanged(idx)
+        }
     }
 
     // ⛔️ 반드시 아래에 DiffUtil 정의가 있어야 함!
@@ -245,12 +274,12 @@ class OrderBookAdapter(
         return when (viewType) {
             VIEW_TYPE_SELL -> {
                 val view = inflater.inflate(R.layout.item_order_book_sell, parent, false)
-                OrderBookViewHolder(view, listener) { pos -> getItem(pos) }
+                OrderBookViewHolder(view, listener, { pos -> getItem(pos) }, this)
             }
 
             VIEW_TYPE_BUY -> {
                 val view = inflater.inflate(R.layout.item_order_book_buy, parent, false)
-                OrderBookViewHolder(view, listener) { pos -> getItem(pos) }
+                OrderBookViewHolder(view, listener, { pos -> getItem(pos) }, this)
             }
 
             else -> {
@@ -285,8 +314,8 @@ class OrderBookAdapter(
                         borderDrawable = borderDrawable,
                         defaultBackground = defaultBackground,
                         openPrice = openPrice,
-                        fixedTextColorResId = textColorResId,
-                        highlightedPosition = highlightedPosition
+                        fixedTextColorResId = textColorResId
+                        // highlightedPrice는 OrderBookAdapter의 필드로 직접 접근
                     )
                 }
             }
@@ -301,7 +330,8 @@ class OrderBookAdapter(
     class OrderBookViewHolder(
         itemView: View,
         private val listener: OnOrderBookItemClickListener,
-        private val getItemForPosition: (Int) -> OrderBookItem?
+        private val getItemForPosition: (Int) -> OrderBookItem?,
+        private val adapter: OrderBookAdapter
     ) : RecyclerView.ViewHolder(itemView) {
 
         private val priceText: TextView? = itemView.findViewById(R.id.text_order_price_v1)
@@ -337,8 +367,7 @@ class OrderBookAdapter(
             borderDrawable: Drawable?,
             defaultBackground: Drawable?,
             openPrice: Float,
-            fixedTextColorResId: Int, // ✅ 외부에서 강제 지정된 색상
-            highlightedPosition: Int
+            fixedTextColorResId: Int
         ) {
             itemView.visibility = View.VISIBLE
 
@@ -389,18 +418,13 @@ class OrderBookAdapter(
             priceText?.setTextColor(textColor)
             percentText?.setTextColor(textColor)
 
-            // 현재가 강조 표시: 가장 가까운 하나의 행에만 테두리 적용
-            val shouldHighlight = bindingAdapterPosition == highlightedPosition
-            
+            // 현재가 강조 표시: 정확히 하나의 행에만 테두리 적용
+            val shouldHighlight = adapter.highlightedPrice != null && item.price == adapter.highlightedPrice
             if (shouldHighlight) {
-                Log.d(TAG, "Highlighting position $bindingAdapterPosition with price: $priceFloat (current: $currentPrice)")
-                // 검은색 테두리 적용
                 itemView.background = borderDrawable
-                // 테두리가 잘 보이도록 패딩 추가
                 itemView.setPadding(4, 4, 4, 4)
             } else {
-                itemView.background = defaultBackground
-                // 기본 패딩으로 되돌림
+                itemView.background = defaultBackground ?: ColorDrawable(Color.TRANSPARENT)
                 itemView.setPadding(0, 0, 0, 0)
             }
 

--- a/app/src/main/java/com/stip/order/book/OrderBookManager.kt
+++ b/app/src/main/java/com/stip/order/book/OrderBookManager.kt
@@ -216,6 +216,10 @@ class OrderBookManager(
             addAll(paddedBuys)
         }
 
+        // 호가창 데이터 업데이트 전에 강조 표시 초기화
+        orderBookAdapter.resetHighlight()
+        
+        // 새로운 데이터로 업데이트
         orderBookAdapter.updateData(listWithoutGap, currentPrice)
     }
 

--- a/app/src/main/java/com/stip/stip/order/button/OrderButtonHandler.kt
+++ b/app/src/main/java/com/stip/stip/order/button/OrderButtonHandler.kt
@@ -40,7 +40,8 @@ class OrderButtonHandler(
     private val parentFragmentManager: FragmentManager,
     private val getCurrentPairId: () -> String?,
     private val orderDataCoordinator: com.stip.stip.order.coordinator.OrderDataCoordinator? = null,
-    private val orderInputHandler: com.stip.stip.order.OrderInputHandler? = null
+    private val orderInputHandler: com.stip.stip.order.OrderInputHandler? = null,
+    private val onOrderSuccess: (() -> Unit)? = null
 ) {
     companion object {
         private const val TAG = "OrderButtonHandler"
@@ -550,6 +551,12 @@ class OrderButtonHandler(
                             
                             // 주문 성공 후 TradingDataHolder 데이터 새로고침 및 TradingFragment 업데이트
                             refreshTradingDataAfterOrder()
+                            
+                            // 실시간 시세 동기화를 위한 즉시 업데이트
+                            orderDataCoordinator?.refreshBalance()
+                            
+                            // 주문 성공 콜백 호출
+                            onOrderSuccess?.invoke()
                             
                             // 주문 성공 후 강제로 주문가능 금액 업데이트 (지연 실행)
                             CoroutineScope(Dispatchers.Main).launch {


### PR DESCRIPTION
## 실시간 시세 동기화 및 마켓페어 정보 폴링
### TradingFragment(거래화면)에 5초 간격 마켓페어 정보 폴링 추가
### 실시간 시세 갱신 문제 해결 (모든 사용자 동기화)
### 주문 체결 후 즉시 호가창 업데이트

---------------------------------------------------------------------------------------------------------------

## 체결된 가격에 맞는 호가에 강조 하이라이트(테두리)
### 체결된 가격에 맞는 호가에 강조 하이라이트(테두리) 되도록 로직 수정
### 체결된 가격과 일치하지 않으면 호가에 강조 하이라이트(테두리) 노출되지 않음

---------------------------------------------------------------------------------------------------------------

## IP내역 > IP투자 소수점 자릿수 포맷팅 수정
### 거래금액 및 정산금액 소수점 4자리까지 나오도록 수정

---------------------------------------------------------------------------------------------------------------

## IP홈 > IP상세 > 시간별 시세
### query params 수정 (from, to → isoDate에서 YYYY-MM-DD 형식으로 수정)
### 최신 거래 내역이 위쪽부터 뜨도록 최신순 조회 수정 완료
### 이전 거래 가격과 비교하여 상승 시 파란색 다운 시 빨간색 변동 없을 시 검은색으로 색깔 매핑 수정

---------------------------------------------------------------------------------------------------------------